### PR TITLE
Generalize poor templating and reuse shared libraries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This document provides guidelines for AI agents working on the poor-tools web in
 - **Dependencies**: Manage with `uv`, pin versions in pyproject.toml
 - **Docker**: Use `hadolint` for Dockerfile linting
 - **Shell scripts**: Use `shellcheck` for shell script linting
+  - All `poor*` scripts in this repository are POSIX `sh`
 
 ### File Organization
 
@@ -64,6 +65,8 @@ This document provides guidelines for AI agents working on the poor-tools web in
 
 - **Templating**: Support `# INCLUDE_FILE: path/to/file.sh` directives
 - **Library functions**: Place reusable functions in `lib/`
+- **Library usage**: Source shared helpers with `. lib/<file>.sh # <TEMPLATE>` so the
+  web installer can inline them automatically
 - **Style**: Follow existing poor-tools style (POSIX shell where possible)
 - **Comments**: Use meaningful comments for complex logic
 - **Variable naming**: Use UPPERCASE for global variables, lowercase for local variables

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ python -m poor_installer_web.app
 ### Available Tools
 
 - **poornmap** - Simple nmap alternative for basic port scanning
+- **poor** - Busybox-style wrapper that fetches and runs other poor-tools
 - **poorcurl** - curl-like wrapper using wget
 - **poorcurl-openssl** - HTTPS client using openssl s_client
 - **poorcolumn** - Minimal column(1) clone with basic -s/-t support
@@ -34,6 +35,9 @@ python -m poor_installer_web.app
 ### Usage Examples
 
 ```bash
+# Run a tool without installing it
+./poor curl https://example.com
+
 # Get info about available tools and installers
 curl -sSL http://localhost:7667/
 
@@ -52,6 +56,16 @@ curl -sSL http://localhost:7667/curl/install | sh -s -- --dest /usr/local/bin --
 # Download individual tools directly:
 curl -sSL http://localhost:7667/curl > ~/.local/bin/poorcurl
 chmod +x ~/.local/bin/poorcurl
+
+# Fetch and run tools through the multiplexer
+curl -sSL http://localhost:7667/poor | sh -s -- curl https://example.com
+curl -sSL http://localhost:7667/poor | sh -s -- install --dest ~/.local/bin
+
+# Install the multiplexer itself and use busybox-style symlinks
+curl -sSL http://localhost:7667/poor > ~/.local/bin/poor
+chmod +x ~/.local/bin/poor
+ln -sf ~/.local/bin/poor ~/.local/bin/curl
+curl https://example.com
 
 # All tool installers available:
 curl -sSL http://localhost:7667/nmap/install | sh          # poornmap
@@ -84,8 +98,8 @@ Options:
 
 ## Local Installation
 
-Run `./poor-installer --dest /some/bin` to copy every tool into your own bin
-directory. Useful flags:
+Run `./poor install --dest /some/bin` (or the legacy `./poor-installer`) to
+copy every tool into your own bin directory. Useful flags:
 
 - `--emulate` strips the `poor` prefix (so `poorcurl` becomes `curl`).
 - `--clear` wipes the destination before installing.
@@ -93,6 +107,36 @@ directory. Useful flags:
 - `--uninstall` removes the files we would install (respects the same flags).
 
 You can also install a subset via globs: `./poor-installer --dest ~/.local/bin 'curl*'`.
+
+## poor multiplexer
+
+The new `poor` script acts as the front-door to the entire toolbox:
+
+```bash
+# Run any tool directly
+poor curl https://example.com
+poor nmap -p 22 example.com
+
+# Same behaviour through symlinks
+ln -s poor poorcurl
+./poorcurl --help
+
+# Install tools using the web installer wrapper
+poor install --dest ~/.local/bin
+```
+
+It supports a few environment variables for customization:
+
+- `POOR_BASE_URL` — override the server or directory used to fetch tools
+- `POOR_TOOL_DIR` — point at an existing directory of poor scripts
+- `POOR_CACHE_DIR` — location to store downloaded copies (defaults to XDG cache)
+- `POOR_DOWNLOADER` — force `curl` or `wget`
+- `POOR_REFRESH=1` — always redownload before running a tool
+- `POOR_NO_CACHE=1` — ignore existing cached copies for a single invocation
+
+When retrieved from the web installer the script automatically targets the
+serving host, so `curl http://localhost:7667/poor | sh -s -- curl example.com`
+works without any manual configuration.
 
 ## License
 

--- a/poor
+++ b/poor
@@ -1,0 +1,482 @@
+#!/usr/bin/env sh
+# description: busybox-style multiplexer for poor-tools
+# icon: mdi:toolbox
+
+set -eu
+
+# Source shared libraries - these lines get replaced during templating
+# shellcheck disable=SC1091  # File is included via templating
+. lib/utils.sh # <TEMPLATE>
+# shellcheck disable=SC1091  # File is included via templating
+. lib/echo.sh # <TEMPLATE>
+
+# shellcheck disable=SC2034  # Used by echo.sh functions
+SCRIPT_NAME="poor"
+
+usage() {
+  cat <<'USAGE' >&2
+Usage:
+  poor TOOL [ARGS...]
+  curl -sSL <server>/poor | sh -s -- TOOL [ARGS...]
+
+Run poor-tools without installing each script. Behaves a bit like busybox:
+  - "poor curl ..." runs poorcurl
+  - Symlink poor to "curl" so running "curl" executes poor curl
+  - "poor install --dest ~/.local/bin" wraps poor-installer
+
+Environment:
+  POOR_BASE_URL       Override the server or directory to fetch tools from
+  POOR_TOOL_DIR       Directory containing already downloaded poor* scripts
+  POOR_CACHE_DIR      Cache directory for downloaded scripts
+  POOR_DOWNLOADER     Force downloader (curl or wget)
+  POOR_REFRESH        If set to 1, always redownload before running
+  POOR_NO_CACHE       If set to 1, do not reuse cached downloads
+USAGE
+}
+
+select_downloader() {
+  if [ -n "${POOR_DOWNLOADER_SELECTED-}" ]
+  then
+    printf '%s' "$POOR_DOWNLOADER_SELECTED"
+    return 0
+  fi
+
+  if [ -n "${POOR_DOWNLOADER-}" ]
+  then
+    case "$POOR_DOWNLOADER" in
+      curl|wget)
+        if has_command "$POOR_DOWNLOADER"
+        then
+          POOR_DOWNLOADER_SELECTED=$POOR_DOWNLOADER
+          printf '%s' "$POOR_DOWNLOADER_SELECTED"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  if has_command curl
+  then
+    POOR_DOWNLOADER_SELECTED=curl
+    printf '%s' "$POOR_DOWNLOADER_SELECTED"
+    return 0
+  fi
+
+  if has_command wget
+  then
+    POOR_DOWNLOADER_SELECTED=wget
+    printf '%s' "$POOR_DOWNLOADER_SELECTED"
+    return 0
+  fi
+
+  echo_error "poor: no downloader (curl or wget) available"
+  return 1
+}
+
+ensure_cache_dir() {
+  if [ -n "${POOR_CACHE_DIR-}" ]
+  then
+    CACHE_DIR=$POOR_CACHE_DIR
+  else
+    if [ -n "${XDG_CACHE_HOME-}" ]
+    then
+      CACHE_DIR=$XDG_CACHE_HOME/poor-tools
+    else
+      if [ -n "${HOME-}" ]
+      then
+        CACHE_DIR=$HOME/.cache/poor-tools
+      else
+        CACHE_DIR=/tmp/poor-tools-cache
+      fi
+    fi
+  fi
+
+  mkdir -p "$CACHE_DIR"
+  printf '%s' "$CACHE_DIR"
+}
+
+strip_trailing_slash() {
+  VALUE=$1
+  case "$VALUE" in
+    */)
+      printf '%s' "${VALUE%/}"
+      ;;
+    *)
+      printf '%s' "$VALUE"
+      ;;
+  esac
+}
+
+build_cache_path() {
+  CACHE_DIR=$(ensure_cache_dir)
+  TARGET=$1
+  printf '%s/%s' "$CACHE_DIR" "$TARGET"
+}
+
+trap_cleanup_prepare() {
+  if [ "${TRAP_INSTALLED-}" = "1" ]
+  then
+    return
+  fi
+
+  TRAP_INSTALLED=1
+  trap 'cleanup_tmp "$TMP_DOWNLOAD"' EXIT INT TERM
+}
+
+cleanup_tmp() {
+  TMP_FILE=$1
+  if [ -n "$TMP_FILE" ] && [ -f "$TMP_FILE" ]
+  then
+    rm -f "$TMP_FILE"
+  fi
+}
+
+finalize_download() {
+  TMP_FILE=$1
+  DEST_PATH=$2
+  EXEC_FLAG=$3
+
+  mv "$TMP_FILE" "$DEST_PATH"
+  if [ "$EXEC_FLAG" = "1" ]
+  then
+    chmod 755 "$DEST_PATH"
+  else
+    chmod 644 "$DEST_PATH"
+  fi
+}
+
+run_downloader() {
+  URL=$1
+  DEST_PATH=$2
+  EXEC_FLAG=$3
+
+  DOWNLOADER=$(select_downloader) || return 1
+
+  DEST_DIR=$(dirname "$DEST_PATH")
+  mkdir -p "$DEST_DIR"
+
+  TMP_DOWNLOAD=${DEST_PATH}.tmp.$$
+  trap_cleanup_prepare
+
+  : > "$TMP_DOWNLOAD"
+
+  if [ "$DOWNLOADER" = "curl" ]
+  then
+    if curl -fsSL "$URL" -o "$TMP_DOWNLOAD"
+    then
+      finalize_download "$TMP_DOWNLOAD" "$DEST_PATH" "$EXEC_FLAG"
+      TMP_DOWNLOAD=""
+      return 0
+    fi
+  else
+    if wget -q "$URL" -O "$TMP_DOWNLOAD"
+    then
+      finalize_download "$TMP_DOWNLOAD" "$DEST_PATH" "$EXEC_FLAG"
+      TMP_DOWNLOAD=""
+      return 0
+    fi
+  fi
+
+  cleanup_tmp "$TMP_DOWNLOAD"
+  TMP_DOWNLOAD=""
+  return 1
+}
+
+download_from_base() {
+  DEST_PATH=$1
+  EXEC_FLAG=$2
+  REMOTE_PATH=$3
+
+  case "$BASE_URL" in
+    *://*)
+      BASE=$(strip_trailing_slash "$BASE_URL")
+      URL=$BASE/$REMOTE_PATH
+      if run_downloader "$URL" "$DEST_PATH" "$EXEC_FLAG"
+      then
+        return 0
+      fi
+      ;;
+    *)
+      SOURCE_DIR=$(strip_trailing_slash "$BASE_URL")
+      SOURCE_PATH=$SOURCE_DIR/$REMOTE_PATH
+      if [ -f "$SOURCE_PATH" ]
+      then
+        DEST_DIR=$(dirname "$DEST_PATH")
+        mkdir -p "$DEST_DIR"
+        cp "$SOURCE_PATH" "$DEST_PATH"
+        if [ "$EXEC_FLAG" = "1" ]
+        then
+          chmod 755 "$DEST_PATH"
+        else
+          chmod 644 "$DEST_PATH"
+        fi
+        return 0
+      fi
+      ;;
+  esac
+
+  return 1
+}
+
+download_candidates() {
+  DEST_PATH=$1
+  EXEC_FLAG=$2
+  shift
+  shift
+
+  while [ $# -gt 0 ]
+  do
+    REMOTE_PATH=$1
+    shift
+    if download_from_base "$DEST_PATH" "$EXEC_FLAG" "$REMOTE_PATH"
+    then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+find_dependencies() {
+  SCRIPT_FILE=$1
+  (
+    while IFS= read -r LINE
+    do
+      case "$LINE" in
+        "# INCLUDE_FILE:"*)
+          INCLUDE=${LINE#\# INCLUDE_FILE:}
+          INCLUDE=${INCLUDE# }
+          if [ -n "$INCLUDE" ]
+          then
+            printf '%s\n' "$INCLUDE"
+          fi
+          ;;
+        *"# <TEMPLATE>"*)
+          # shellcheck disable=SC2086
+          set -- $LINE
+          if [ $# -ge 2 ]
+          then
+            FIRST_WORD=$1
+            SECOND_WORD=$2
+            if [ "$FIRST_WORD" = "." ] || [ "$FIRST_WORD" = "source" ]
+            then
+              case "$SECOND_WORD" in
+                lib/*)
+                  printf '%s\n' "$SECOND_WORD"
+                  ;;
+              esac
+            fi
+          fi
+          ;;
+      esac
+    done < "$SCRIPT_FILE"
+  )
+}
+
+ensure_dependencies() {
+  SCRIPT_FILE=$1
+  DEPENDENCIES=$(find_dependencies "$SCRIPT_FILE")
+  if [ -z "$DEPENDENCIES" ]
+  then
+    return 0
+  fi
+
+  SCRIPT_DIRNAME=$(dirname "$SCRIPT_FILE")
+
+  for DEP in $DEPENDENCIES
+  do
+    TARGET_PATH=$SCRIPT_DIRNAME/$DEP
+    if [ -f "$TARGET_PATH" ]
+    then
+      continue
+    fi
+
+    if download_candidates "$TARGET_PATH" 0 "$DEP"
+    then
+      ensure_dependencies "$TARGET_PATH"
+      continue
+    fi
+
+    echo_error "poor: failed to fetch dependency $DEP"
+    return 1
+  done
+
+  return 0
+}
+
+normalize_tool_name() {
+  REQUEST=$1
+
+  case "$REQUEST" in
+    "")
+      return 1
+      ;;
+    poor|poor.sh)
+      return 1
+      ;;
+    install|installer)
+      printf '%s' "poor-installer"
+      return 0
+      ;;
+    poor-install|poor-installer)
+      printf '%s' "poor-installer"
+      return 0
+      ;;
+  esac
+
+  case "$REQUEST" in
+    poor-*)
+      STRIPPED=${REQUEST#poor-}
+      REQUEST=$STRIPPED
+      ;;
+  esac
+
+  case "$REQUEST" in
+    poor*)
+      printf '%s' "$REQUEST"
+      return 0
+      ;;
+  esac
+
+  printf '%s' "poor$REQUEST"
+  return 0
+}
+
+resolve_invocation() {
+  RAW_NAME=$1
+
+  case "$RAW_NAME" in
+    sh|dash|bash|ksh|mksh|zsh)
+      printf '%s' "poor"
+      return 0
+      ;;
+  esac
+
+  printf '%s' "$RAW_NAME"
+}
+
+DEFAULT_BASE_URL="<BASE_URL>"
+if [ "$DEFAULT_BASE_URL" = "<BASE_URL>" ]
+then
+  DEFAULT_BASE_URL="https://poor.tools"
+fi
+
+if [ -n "${POOR_BASE_URL-}" ]
+then
+  BASE_URL=$POOR_BASE_URL
+else
+  BASE_URL=$DEFAULT_BASE_URL
+fi
+
+SCRIPT_DIR=""
+if [ -n "${POOR_TOOL_DIR-}" ]
+then
+  SCRIPT_DIR=$POOR_TOOL_DIR
+else
+  if RESOLVED_DIR=$(get_script_dir "$0" 2>/dev/null)
+  then
+    if [ -n "$RESOLVED_DIR" ]
+    then
+      SCRIPT_DIR=$RESOLVED_DIR
+    fi
+  fi
+fi
+
+SELF_NAME_RAW=$(basename "$0")
+SELF_NAME=$(resolve_invocation "$SELF_NAME_RAW")
+
+if [ "$SELF_NAME" = "poor" ]
+then
+  if [ $# -eq 0 ]
+  then
+    usage
+    exit 0
+  fi
+
+  case "$1" in
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    list)
+      if [ -n "$SCRIPT_DIR" ] && [ -d "$SCRIPT_DIR" ]
+      then
+        for FILE in "$SCRIPT_DIR"/poor*
+        do
+          if [ -f "$FILE" ]
+          then
+            BASENAME=$(basename "$FILE")
+            printf '%s\n' "$BASENAME"
+          fi
+        done
+      fi
+
+      if [ -n "${BASE_URL}" ]
+      then
+        printf '%s\n' "Base: $BASE_URL"
+      fi
+      exit 0
+      ;;
+  esac
+
+  TOOL_REQUEST=$1
+  shift
+else
+  TOOL_REQUEST=$SELF_NAME
+fi
+
+TARGET_NAME=$(normalize_tool_name "$TOOL_REQUEST" || printf '')
+if [ -z "$TARGET_NAME" ]
+then
+  echo_error "poor: unable to determine tool for '$TOOL_REQUEST'"
+  exit 1
+fi
+
+if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/$TARGET_NAME" ]
+then
+  exec "$SCRIPT_DIR/$TARGET_NAME" "$@"
+fi
+
+if command -v "$TARGET_NAME" >/dev/null 2>&1
+then
+  EXEC_PATH=$(command -v "$TARGET_NAME")
+  exec "$EXEC_PATH" "$@"
+fi
+
+CACHE_PATH=$(build_cache_path "$TARGET_NAME")
+
+if [ "${POOR_REFRESH-0}" = "1" ] || [ "${POOR_NO_CACHE-0}" = "1" ]
+then
+  rm -f "$CACHE_PATH"
+fi
+
+if [ "${POOR_NO_CACHE-0}" = "0" ] && [ -f "$CACHE_PATH" ]
+then
+  chmod 755 "$CACHE_PATH"
+  ensure_dependencies "$CACHE_PATH"
+  exec "$CACHE_PATH" "$@"
+fi
+
+PRIMARY_PATH=$TARGET_NAME
+SECONDARY_PATH=""
+case "$TARGET_NAME" in
+  poor*)
+    ALT_NAME=${TARGET_NAME#poor}
+    if [ -n "$ALT_NAME" ]
+    then
+      SECONDARY_PATH=$ALT_NAME
+    fi
+    ;;
+esac
+
+if [ -n "$SECONDARY_PATH" ]
+then
+  download_candidates "$CACHE_PATH" 1 "$PRIMARY_PATH" "$SECONDARY_PATH"
+else
+  download_candidates "$CACHE_PATH" 1 "$PRIMARY_PATH"
+fi
+
+ensure_dependencies "$CACHE_PATH"
+
+chmod 755 "$CACHE_PATH"
+exec "$CACHE_PATH" "$@"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -177,6 +177,17 @@ def test_all_tool_endpoints() -> None:
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/plain; charset=utf-8"
 
+    # Test poor multiplexer endpoint
+    response = client.get("/poor")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
+    assert '<BASE_URL>' not in response.text
+    assert 'DEFAULT_BASE_URL="http://testserver"' in response.text
+
+    response = client.get("/poor", params={"no_templating": "1"})
+    assert response.status_code == 200
+    assert '<BASE_URL>' in response.text
+
 
 def test_templating_disabled() -> None:
     """Test that templating can be disabled."""


### PR DESCRIPTION
## Summary
- source shared shell helpers in the poor multiplexer and rely on the common get_script_dir utility
- switch the poor default base URL placeholder to <BASE_URL> and handle placeholder replacement for all scripts in the web service
- document the templated include pattern for agents and update API tests for the new placeholder behaviour

## Testing
- shellcheck poor
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68e43c7437808323a92231b31091f218